### PR TITLE
Update plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,6 @@
 
         <!-- Plugins Version -->
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <!--
-            http://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven
-            > Due to a memory leak in Surefire 2.20, the junit-platform-surefire-provider currently only works with Surefire 2.19.1.
-        -->
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
         <!-- Dependencies Version -->
         <docker-compose-rule.version>0.32.1</docker-compose-rule.version>
-        <junit-platform.version>1.0.1</junit-platform.version>
-        <junit-jupiter.version>5.0.1</junit-jupiter.version>
+        <junit-platform.version>1.2.0-M1</junit-platform.version>
+        <junit-jupiter.version>5.2.0</junit-jupiter.version>
         <postgresql.version>42.1.4</postgresql.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <unirest-java.version>1.4.9</unirest-java.version>
@@ -34,7 +34,7 @@
             http://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven
             > Due to a memory leak in Surefire 2.20, the junit-platform-surefire-provider currently only works with Surefire 2.19.1.
         -->
-        <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Thank you for the project. It saved me a lot of time.
In the meantime the versions are moving forward.
We can use the latest version of maven-surefire-plugin (2.21.0) with almost released junit-platform (1.2.0-M1)